### PR TITLE
Trim prefixes that end with '_-' so that they end with '-' only

### DIFF
--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -65,6 +65,20 @@ def generate_robot_2_rst(robot_file, rst_file, prefixes, tag_regex):
     )
 
 
+def _tweak_prefix(prefix):
+    """ If a prefix or regex ends in '_-', change it to '-'
+
+    Args:
+        prefix (str): Prefix that might need tweaking.
+
+    Returns:
+        (str) Prefix that has been tweaked if it needed to.
+    """
+    if prefix.endswith('_-'):
+        prefix = prefix.rstrip('_-') + '-'
+    return prefix
+
+
 def main():
     '''Main entry point for script: parse arguments and execute'''
     parser = argparse.ArgumentParser(description='Convert robot to RsT.')
@@ -99,9 +113,9 @@ def main():
     }
     for key, option in options.items():
         if option is not None:
-            prefixes[key] = option
+            prefixes[key] = _tweak_prefix(option)
 
-    generate_robot_2_rst(args.robot_file, args.rst_file, prefixes, args.tag_regex)
+    generate_robot_2_rst(args.robot_file, args.rst_file, prefixes, _tweak_prefix(args.tag_regex))
 
 
 if __name__ == "__main__":

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -48,6 +48,7 @@ def render_template(destination, **kwargs):
 def generate_robot_2_rst(robot_file, rst_file, prefixes, tag_regex):
     """
     Calls mako template function and passes all needed parameters.
+
     Args:
         robot_file (str): Path to the input file (.robot).
         rst_file (str): Path to the output file (.rst).
@@ -66,7 +67,7 @@ def generate_robot_2_rst(robot_file, rst_file, prefixes, tag_regex):
 
 
 def _tweak_prefix(prefix):
-    """ If a prefix or regex ends in '_-', change it to '-'
+    """ If a prefix or regex ends with '_-', change it to end with '-' instead.
 
     Args:
         prefix (str): Prefix that might need tweaking.

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -97,8 +97,8 @@ def main():
                         help="Overrides default 'VARIABLE-' prefix.")
     parser.add_argument("--tags", dest='tag_regex', action='store', default='.*',
                         help="Regex for matching tags to add a relationship link for. All tags get matched by default.")
-    parser.add_argument("--adjust_suffix", action='store_false',
-                        help="If the suffix of any prefix or --tags argument ends with '_-' it gets adjusted to '-'")
+    parser.add_argument("--trim_suffix", action='store_false',
+                        help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'")
 
     args = parser.parse_args()
 
@@ -116,12 +116,12 @@ def main():
     }
     for key, option in options.items():
         if option is not None:
-            if args.adjust_suffix:
+            if args.trim_suffix:
                 option = _tweak_prefix(option)
             prefixes[key] = option
 
     tag_regex = args.tag_regex
-    if args.adjust_suffix:
+    if args.trim_suffix:
         tag_regex = _tweak_prefix(tag_regex)
 
     generate_robot_2_rst(args.robot_file, args.rst_file, prefixes, tag_regex)

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -97,6 +97,8 @@ def main():
                         help="Overrides default 'VARIABLE-' prefix.")
     parser.add_argument("--tags", dest='tag_regex', action='store', default='.*',
                         help="Regex for matching tags to add a relationship link for. All tags get matched by default.")
+    parser.add_argument("--adjust_suffix", action='store_false',
+                        help="If the suffix of any prefix or --tags argument ends with '_-' it gets adjusted to '-'")
 
     args = parser.parse_args()
 
@@ -114,9 +116,15 @@ def main():
     }
     for key, option in options.items():
         if option is not None:
-            prefixes[key] = _tweak_prefix(option)
+            if args.adjust_suffix:
+                option = _tweak_prefix(option)
+            prefixes[key] = option
 
-    generate_robot_2_rst(args.robot_file, args.rst_file, prefixes, _tweak_prefix(args.tag_regex))
+    tag_regex = args.tag_regex
+    if args.adjust_suffix:
+        tag_regex = _tweak_prefix(tag_regex)
+
+    generate_robot_2_rst(args.robot_file, args.rst_file, prefixes, tag_regex)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added `--trim-suffix` flag, which, when enabled, trims the `--tag` and all prefix input arguments that end with `_-` so that this suffix gets changed to a `-` only.