### PR TITLE
Only generate items out of test cases and add traceability matrix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
-.. image:: https://travis-ci.com/melexis/robot2rst.png?branch=master
+.. image:: https://api.travis-ci.com/melexis/robot2rst.svg?branch=master
     :target: https://travis-ci.com/melexis/robot2rst
     :alt: Build status
 
-.. image:: https://img.shields.io/badge/Documentation-published-brightgreen.png
+.. image:: https://img.shields.io/badge/Documentation-published-brightgreen.svg
     :target: https://melexis.github.io/robot2rst/
     :alt: Documentation
 
-.. image:: https://img.shields.io/badge/contributions-welcome-brightgreen.png
+.. image:: https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat
     :target: https://github.com/melexis/robot2rst/issues
     :alt: Contributions welcome
 
@@ -20,34 +20,28 @@ This script can convert your .robot files from Robot Framework to reStructuredTe
     :depth: 2
     :local:
 
-.. _`mlx.traceability`: https://pypi.org/project/mlx.traceability/
-
 ----
 Goal
 ----
 
 This script allows you to connect your requirements to test cases via the `mlx.traceability`_ Sphinx extension.
-The `sphinxcontrib-robotdoc`_ Sphinx extension is responsible for embedding the Robot Framework content with syntax
-highlighting.
+Test cases get converted to traceable items. The documentation of each test gets used to generate the body of the item.
+Test case names get converted to item IDs with a configurable prefix. Tags can be used to link to other traceable items.
 
 -------------
 Configuration
 -------------
 
-To include the script's output in your documentation you want to add the two aforementioned extensions to your
+To include the script's output in your documentation you want to add the aforementioned extension to your
 ``extensions`` list in your *conf.py* like so:
 
 .. code-block:: python
 
     extensions = [
-        'sphinxcontrib_robotdoc',
         'mlx.traceability',
     ]
 
-Please read the `documentation of mlx.traceability`_ and `LaTeX configuration for sphinxcontrib-robotdoc`_ for
-additional configuration steps.
+Please read the `documentation of mlx.traceability`_ for additional configuration steps.
 
 .. _`mlx.traceability`: https://pypi.org/project/mlx.traceability/
-.. _`sphinxcontrib-robotdoc`: https://pypi.org/project/sphinxcontrib-robotdoc/
 .. _`documentation of mlx.traceability`: https://melexis.github.io/sphinx-traceability-extension/readme.html
-.. _`LaTeX configuration for sphinxcontrib-robotdoc`: https://github.com/datakurre/sphinxcontrib-robotdoc#latex-output

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,39 @@ This script allows you to connect your requirements to test cases via the `mlx.t
 Test cases get converted to traceable items. The documentation of each test gets used to generate the body of the item.
 Test case names get converted to item IDs with a configurable prefix. Tags can be used to link to other traceable items.
 
+-----
+Usage
+-----
+
+.. code-block:: console
+
+    robot2rst -i example.robot -o test_plan.rst --prefix ITEST_MY_LIB- --tags SWRQT- SYSRQT- --relationships validates ext_polarion
+
+    $ robot2rst --help
+
+    usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [-p PREFIX]
+                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]]
+                     [-t [TAGS [TAGS ...]]] [--trim-suffix]
+
+    Convert robot test cases to reStructuredText with traceable items.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -i ROBOT_FILE, --robot ROBOT_FILE
+                            Input robot file
+      -o RST_FILE, --rst RST_FILE
+                            Output RST file
+      -p PREFIX, --prefix PREFIX
+                            Overrides the default 'ITEST-' prefix.
+      -r [RELATIONSHIPS [RELATIONSHIPS ...]], --relationships [RELATIONSHIPS [RELATIONSHIPS ...]]
+                            Name(s) of the relationship(s) used to link to items
+                            in Tags section.
+      -t [TAGS [TAGS ...]], --tags [TAGS [TAGS ...]]
+                            Regex(es) for matching tags to add a relationship link
+                            for. All tags get matched by default.
+      --trim-suffix         If the suffix of any prefix or --tags argument ends
+                            with '_-' it gets trimmed to '-'.
+
 -------------
 Configuration
 -------------

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Usage
 
 .. code-block:: console
 
-    robot2rst -i example.robot -o test_plan.rst --prefix ITEST_MY_LIB- --tags SWRQT- SYSRQT- --relationships validates ext_polarion
+    robot2rst -i example.robot -o test_plan.rst --prefix ITEST_MY_LIB- --tags SWRQT- SYSRQT- --relationships validates ext_toolname
 
     $ robot2rst --help
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,5 +19,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(ROBOT2RST) --robot source/robot/example.robot --rst source/example_usage.rst --tags ^RQT-$
+	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -54,6 +54,19 @@ extensions = [
     'mlx.traceability',
 ]
 
+traceability_relationships = {
+    'validates': 'validated_by',
+    'ext_toolname': '',
+}
+traceability_relationship_to_string = {
+    'validates': 'Validates',
+    'validated_by': 'Validated by',
+    'ext_toolname': 'Reference to toolname'
+}
+traceability_external_relationship_to_url = {
+    'ext_toolname': 'http://toolname.company.com/my_lib/system-requirements.html#field1'
+}
+
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 # 'papersize': 'letterpaper',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@ from pygments.formatters import LatexFormatter
 # -- Project information -----------------------------------------------------
 
 project = 'mlx.robot2rst'
-copyright = '2019, Jasper Craeghs'
+copyright = '2020, Jasper Craeghs'
 authors = ['Stein Heselmans', 'Jasper Craeghs']
 
 # The full version, including alpha/beta/rc tags
@@ -51,22 +51,18 @@ texinfo_documents = [
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib_robotdoc',
     'mlx.traceability',
 ]
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+# 'papersize': 'letterpaper',
 
 # The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+# 'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-    'preamble': '''\
-\\usepackage{fancyvrb}
-\\usepackage{color}
-''' + LatexFormatter().get_style_defs()
+# 'preamble': ''
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/requirements.rst
+++ b/doc/source/requirements.rst
@@ -2,6 +2,10 @@
 Requirements
 ============
 
-.. item:: RQT-SOME_RQT Some requirement
+.. item:: SWRQT-SOME_RQT Some requirement
 
     A traceability item that gets validated by a robot test case that has the item ID in its tags.
+
+.. item:: SWRQT-OTHER_RQT Another requirement
+
+    Another traceability item.

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -6,16 +6,24 @@ Library          OperatingSystem
 ${MESSAGE}       Hello, world!
 
 *** Test Cases ***
-My Test
-    [Documentation]    Example test
-    [Tags]             RQT-SOME_RQT  ANOTHER_TAG
-    Log    ${MESSAGE}
-    My Keyword    /tmp
+First Test
+    [Documentation]     Thorough and relatively lengthy documentation for the first example
+    ...                 test case.
+    [Tags]              SWRQT-SOME_RQT  ANOTHER-TAG  SWRQT-OTHER_RQT  SYSRQT-SOME_SYSTEM_RQT
+                        Log    ${MESSAGE}
+                        My Keyword    /tmp
+
+Undocumented Test
+                        Should Be Equal     ${MESSAGE}    Hello, world!
 
 Another Test
-    Should Be Equal    ${MESSAGE}    Hello, world!
+    [Documentation]     Short documentation string.
+    [Tags]              RQT-SOME_RQT  SYSRQT-SOME_SYSTEM_RQT
+                        Log    ${MESSAGE}
+                        My Keyword    /tmp
 
 *** Keywords ***
 My Keyword
-    [Arguments]    ${path}
-    Directory Should Exist    ${path}
+    [Documentation]     My keyword's documentation string.
+    [Arguments]         ${path}
+                        Directory Should Exist    ${path}

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -1,5 +1,5 @@
 <%
-import robot
+from robot.parsing.model import TestData
 import re
 import textwrap
 
@@ -48,14 +48,16 @@ ${'='*len(suite)}
     :local:
 
 
-% for test in robot.parsing.TestData(source=robot_file).testcase_table.tests:
+% for test in TestData(source=robot_file).testcase_table.tests:
 .. item:: ${to_traceable_item(test.name, prefix)} ${test.name}
+% for relationship, tag_regex in relationship_to_tag_mapping.items():
 <%
 filtered_tags = [tag for tag in test.tags if re.search(tag_regex, tag)]
 %>\
-% if filtered_tags:
+    % if filtered_tags:
     :${relationship}: ${' '.join(filtered_tags)}
-% endif
+    % endif
+% endfor
 
 % if str(test.doc):
 ${generate_body(str(test.doc))}
@@ -66,14 +68,17 @@ ${generate_body(str(test.doc))}
 Traceability matrix
 ===================
 
-The below table traces the test cases to the validated software requirements.
+% for relationship, tag_regex in relationship_to_tag_mapping.items():
+The below table traces the integration test cases to the ${relationship} requirements.
 
-.. item-matrix:: Linking these integration test cases to the validated software requirements
+.. item-matrix:: Linking these integration test cases to the ${relationship} requirements
     :source: ${prefix}
     :target: ${tag_regex}
     :sourcetitle: Integration test case
-    :targettitle: Validated software requirement
+    :targettitle: ${relationship} requirement
     :type: ${relationship}
     :stats:
     :group:
     :nocaptions:
+
+% endfor

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -1,8 +1,5 @@
 
-'''
-Script to convert a robot test file to an RST file with traceability items
-'''
-
+''' Script to convert a robot test file to a reStructuredText file with traceable items '''
 import argparse
 import logging
 from pathlib import Path
@@ -40,22 +37,24 @@ def render_template(destination, **kwargs):
         out.close()
 
 
-def generate_robot_2_rst(robot_file, rst_file, prefixes, tag_regex):
+def generate_robot_2_rst(robot_file, rst_file, prefix, tag_regex, relationship):
     """
     Calls mako template function and passes all needed parameters.
 
     Args:
         robot_file (Path): Path to the input file (.robot).
         rst_file (Path): Path to the output file (.rst).
-        prefixes (dict): Dictionary of prefixes for each category.
+        prefix (str): Prefix of generated item IDs.
         tag_regex (str): Regular expression for matching tags to add a relationship link for.
+        relationship (str): Name of the relationship.
     """
     render_template(
         rst_file,
         suite=rst_file.stem,
         robot_file=str(robot_file.resolve(strict=True)),
-        prefixes=prefixes,
+        prefix=prefix,
         tag_regex=tag_regex,
+        relationship=relationship,
     )
 
 
@@ -76,40 +75,30 @@ def _tweak_prefix(prefix):
 def main():
     '''Main entry point for script: parse arguments and execute'''
     parser = argparse.ArgumentParser(description='Convert robot to RsT.')
-    parser.add_argument("--robot", dest='robot_file', help='Input robot file', required=True,
+    parser.add_argument("-i", "--robot", dest='robot_file', help='Input robot file', required=True,
                         action='store')
-    parser.add_argument("--rst", dest='rst_file', help='Output RsT file', required=True,
+    parser.add_argument("-o", "--rst", dest='rst_file', help='Output RsT file', required=True,
                         action='store')
-    parser.add_argument("-k", dest='keyword_prefix', action='store', default='KEYWORD-',
-                        help="Overrides default 'KEYWORD-' prefix.")
-    parser.add_argument("-s", dest='setting_prefix', action='store', default='SETTING-',
-                        help="Overrides default 'SETTING-' prefix.")
     parser.add_argument("-t", dest='test_case_prefix', action='store', default='ITEST-',
                         help="Overrides default 'ITEST-' prefix.")
-    parser.add_argument("-v", dest='variable_prefix', action='store', default='VARIABLE-',
-                        help="Overrides default 'VARIABLE-' prefix.")
+    parser.add_argument("-r", "--relationship", action='store', default='validates',
+                        help="Name of the relationship used to link to items in Tags section.")
     parser.add_argument("--tags", dest='tag_regex', action='store', default='.*',
                         help="Regex for matching tags to add a relationship link for. All tags get matched by default.")
     parser.add_argument("--trim-suffix", action='store_true',
-                        help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'")
+                        help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'.")
 
     args = parser.parse_args()
 
-    prefixes = {
-        'keyword': args.keyword_prefix,
-        'setting': args.setting_prefix,
-        'test_case': args.test_case_prefix,
-        'variable': args.variable_prefix,
-    }
-    for key, prefix in prefixes.items():
-        if args.trim_suffix:
-            prefixes[key] = _tweak_prefix(prefix)
+    prefix = args.test_case_prefix
+    if args.trim_suffix:
+        prefix = _tweak_prefix(prefix)
 
     tag_regex = args.tag_regex
     if args.trim_suffix:
         tag_regex = _tweak_prefix(tag_regex)
 
-    generate_robot_2_rst(Path(args.robot_file), Path(args.rst_file), prefixes, tag_regex)
+    generate_robot_2_rst(Path(args.robot_file), Path(args.rst_file), prefix, tag_regex, args.relationship)
 
 
 if __name__ == "__main__":

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -72,10 +72,10 @@ def _tweak_prefix(prefix):
 
 def main():
     '''Main entry point for script: parse arguments and execute'''
-    parser = argparse.ArgumentParser(description='Convert robot to RsT.')
+    parser = argparse.ArgumentParser(description='Convert robot test cases to reStructuredText with traceable items.')
     parser.add_argument("-i", "--robot", dest='robot_file', help='Input robot file', required=True,
                         action='store')
-    parser.add_argument("-o", "--rst", dest='rst_file', help='Output RsT file', required=True,
+    parser.add_argument("-o", "--rst", dest='rst_file', help='Output RST file', required=True,
                         action='store')
     parser.add_argument("-p", "--prefix", action='store', default='ITEST-',
                         help="Overrides the default 'ITEST-' prefix.")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/robot2rst'
 
-requires = ['robotframework', 'sphinxcontrib-robotdoc>=0.11.0,<0.12.0', 'mlx.traceability', 'mako']
+requires = ['robotframework', 'mlx.traceability', 'mako']
 
 setup(
     name='mlx.robot2rst',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/robot2rst'
 
-requires = ['robotframework', 'mlx.traceability', 'mako']
+requires = ['robotframework<=3.1.2', 'mlx.traceability', 'mako']
 
 setup(
     name='mlx.robot2rst',
@@ -36,6 +36,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     setup_requires=['setuptools_scm'],
+    python_requires='>=3.6',
     namespace_packages=['mlx'],
     keywords=['robot', 'robotframework', 'sphinx', 'traceability'],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ usedevelop = true
 deps=
     mock
     mako
-    sphinxcontrib_robotdoc>=0.11.0
     sphinx-testing >= 1.0.0
     sphinx_rtd_theme
     mlx.traceability >= 4.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,6 @@ whitelist_externals =
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 .tox/doc_html.log
-    bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 .tox/doc_pdf.log
 
 [testenv:sphinx-latest]
 deps=
@@ -61,5 +59,3 @@ whitelist_externals =
 commands=
     bash -c 'make -C doc html 2>&1 | tee .tox/doc_html.log'
     mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 .tox/doc_html.log
-    bash -c 'make -C doc latexpdf 2>&1 | tee .tox/doc_pdf.log'
-    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 .tox/doc_pdf.log


### PR DESCRIPTION
Thanks to these changes the `sphinxcontrib_robotdoc` extension is no longer a dependency and .robot files are not needed by Sphinx to generate the final documentation.

Furthermore, multiple regexes are now supported to match different kind of tags and add a specific relation for each kind of tag.