### PR TITLE
Drop dependency to mlx.traceability 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description_content_type='text/x-rst',
     zip_safe=False,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/robot2rst'
 
-requires = ['robotframework<=3.1.2', 'mlx.traceability', 'mako']
+requires = ['robotframework<=3.1.2', 'mako']
 
 setup(
     name='mlx.robot2rst',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Documentation',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Utilities',


### PR DESCRIPTION
The dependency to the module [mlx.traceability](https://pypi.org/project/mlx.traceability/) was removed as it is not used by mlx.robot2rst.