### PR TITLE
Preserve line endings and indents of docstrings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,8 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
-PYTHON		  = python3
-ROBOT2RST	  = $(PYTHON) -m mlx.robot2rst
+ROBOT2RST	  = robot2rst
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -19,5 +18,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname
+	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -r validates
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,8 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
-PYTHON		  = python3
-ROBOT2RST	  = $(PYTHON) -m mlx.robot2rst
+ROBOT2RST	  = robot2rst
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,8 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
-ROBOT2RST	  = robot2rst
+PYTHON		  = python3
+ROBOT2RST	  = $(PYTHON) -m mlx.robot2rst
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -18,5 +19,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -r validates
+	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -8,7 +8,7 @@ ${MESSAGE}       Hello, world!
 *** Test Cases ***
 First Test
     [Documentation]     Thorough and relatively lengthy documentation for the first example
-    ...                 test case.
+    ...  test case.
     [Tags]              SWRQT-SOME_RQT  ANOTHER-TAG  SWRQT-OTHER_RQT  SYSRQT-SOME_SYSTEM_RQT
                         Log    ${MESSAGE}
                         My Keyword    /tmp
@@ -19,12 +19,16 @@ Undocumented Test
 Test with raw docs
     [Documentation]     An example docstring for which it's important its line endings get preserved.
     ...
-    ...    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    ...    - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    ...  - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+    ...    dolore magna aliqua.
+    ...  - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    ...
+    ...      - Nested bullet point
                         Log  The line endings of a docstring that starts with *RAW* get preserved.
 
 Another Test
-    [Documentation]     Short documentation string.
+    [Documentation]
+    ...  Short documentation string.
     [Tags]              RQT-SOME_RQT  SYSRQT-SOME_SYSTEM_RQT
                         Log    ${MESSAGE}
                         My Keyword    /tmp

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -24,7 +24,7 @@ Test with raw docs
     ...  - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     ...
     ...      - Nested bullet point
-                        Log  The line endings of a docstring that starts with *RAW* get preserved.
+                        Log  The line endings and indents in a docstring get preserved.
 
 Another Test
     [Documentation]

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -16,6 +16,13 @@ First Test
 Undocumented Test
                         Should Be Equal     ${MESSAGE}    Hello, world!
 
+Test with raw docs
+    [Documentation]     *RAW* An example docstring of which the line endings get preserved.
+    ...
+    ...    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    ...    - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                        Log  The line endings of a docstring that starts with *RAW* get preserved.
+
 Another Test
     [Documentation]     Short documentation string.
     [Tags]              RQT-SOME_RQT  SYSRQT-SOME_SYSTEM_RQT

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -16,7 +16,7 @@ First Test
 Undocumented Test
                         Should Be Equal     ${MESSAGE}    Hello, world!
 
-Test with raw docs
+Test with documentation in RST syntax
     [Documentation]     An example docstring for which it's important its line endings get preserved.
     ...
     ...  - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et

--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -17,7 +17,7 @@ Undocumented Test
                         Should Be Equal     ${MESSAGE}    Hello, world!
 
 Test with raw docs
-    [Documentation]     *RAW* An example docstring of which the line endings get preserved.
+    [Documentation]     An example docstring for which it's important its line endings get preserved.
     ...
     ...    - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     ...    - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -37,6 +37,7 @@ def generate_body(input_string):
     line_separator = newline + indent
     input_string = input_string.replace(r'\r', '')
     if input_string.startswith('*RAW*'):
+        input_string = input_string[len('*RAW*'):]
         line_ending = r'\n'
     else:
         input_string = input_string.replace(r'\n', ' ')

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -32,9 +32,15 @@ def generate_body(input_string):
     Returns:
         str: Indented body, which has been word wrapped to not exceed 120 characters
     '''
-    no_newlines_input = input_string.replace(r'\r', '').replace(r'\n', ' ')
     indent = ' ' * 4
-    return indent + textwrap.fill(no_newlines_input, 115).replace('\n', '\n' + indent).strip()
+    input_string = input_string.replace(r'\r', '')
+    if input_string.startswith('*RAW*'):
+        intermediate_output = input_string.replace(r'\n', '\n' + indent)
+    else:
+        no_newlines_input = input_string.replace(r'\n', ' ')
+        intermediate_output = textwrap.fill(no_newlines_input, 115)
+        intermediate_output = intermediate_output.replace('\n', '\n' + indent)
+    return indent + intermediate_output.strip()
 %>\
 .. _${suite.replace(' ', '_')}:
 
@@ -59,7 +65,7 @@ filtered_tags = [tag for tag in test.tags if re.search(tag_regex, tag)]
 % endfor
 
 % if str(test.doc):
-${generate_body(str(test.doc))}
+${generate_body(str(test.doc).strip())}
 
 %endif
 % endfor

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -33,13 +33,18 @@ def generate_body(input_string):
         str: Indented body, which has been word wrapped to not exceed 120 characters
     '''
     indent = ' ' * 4
+    newline = '\n'
+    line_separator = newline + indent
     input_string = input_string.replace(r'\r', '')
     if input_string.startswith('*RAW*'):
-        intermediate_output = input_string.replace(r'\n', '\n' + indent)
+        line_ending = r'\n'
     else:
-        no_newlines_input = input_string.replace(r'\n', ' ')
-        intermediate_output = textwrap.fill(no_newlines_input, 115)
-        intermediate_output = intermediate_output.replace('\n', '\n' + indent)
+        input_string = input_string.replace(r'\n', ' ')
+        input_string = textwrap.fill(input_string, 115)
+        line_ending = '\n'
+    lines = input_string.split(line_ending)
+    intermediate_output = line_separator.join(map(str.strip, lines))
+    intermediate_output = intermediate_output.replace(newline + indent + newline, newline * 2)
     return indent + intermediate_output.strip()
 %>\
 .. _${suite.replace(' ', '_')}:

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -25,20 +25,27 @@ def to_traceable_item(name, prefix=''):
 def generate_body(input_string):
     ''' Generates the body of the item based on the raw docstring of the robot test case.
 
+    Indents and line endings are preserved, except for the indent of the first line, which gets removed.
+
     Args:
         input_string (str): Raw docstring.
 
     Returns:
-        str: Indented body, which has been word wrapped to not exceed 120 characters
+        str: Body of the item, which is the input string with an added indent of four spaces
     '''
     indent = ' ' * 4
     newline = '\n'
     line_separator = newline + indent
-    input_string = input_string.replace(r'\r', '')
-    lines = input_string.split(r'\n')
-    intermediate_output = line_separator.join(map(str.strip, lines))
-    intermediate_output = intermediate_output.replace(newline + indent + newline, newline * 2)
-    return indent + intermediate_output.strip()
+    input_string = input_string.replace(r'\r', '').strip()
+    lines = input_string.split(newline)
+    intermediate_output = indent
+    for line in lines:
+        if line:
+            intermediate_output += line.rstrip()
+        else:
+            intermediate_output =  intermediate_output.rstrip(' ')
+        intermediate_output += line_separator
+    return intermediate_output.rstrip()
 %>\
 .. _${suite.replace(' ', '_')}:
 
@@ -63,7 +70,7 @@ filtered_tags = [tag for tag in test.tags if re.search(tag_regex, tag)]
 % endfor
 
 % if str(test.doc):
-${generate_body(str(test.doc).strip())}
+${generate_body(str(test.doc))}
 
 %endif
 % endfor

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -1,6 +1,5 @@
 <%
 import re
-import textwrap
 
 def to_traceable_item(name, prefix=''):
     '''
@@ -36,14 +35,7 @@ def generate_body(input_string):
     newline = '\n'
     line_separator = newline + indent
     input_string = input_string.replace(r'\r', '')
-    if input_string.startswith('*RAW*'):
-        input_string = input_string[len('*RAW*'):]
-        line_ending = r'\n'
-    else:
-        input_string = input_string.replace(r'\n', ' ')
-        input_string = textwrap.fill(input_string, 115)
-        line_ending = '\n'
-    lines = input_string.split(line_ending)
+    lines = input_string.split(r'\n')
     intermediate_output = line_separator.join(map(str.strip, lines))
     intermediate_output = intermediate_output.replace(newline + indent + newline, newline * 2)
     return indent + intermediate_output.strip()

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -99,8 +99,8 @@ def main():
     if not args.tags:
         args.tags = ['.*']
         gen_matrix = False
-        LOGGER.warning(f"No traceability matrix will be generated because of the use of default tag regex "
-                       f"{args.tags[0]!r}.")
+        LOGGER.warning("No traceability matrix will be generated because of the use of default tag regex %r.",
+                       args.tags[0])
     if not args.relationships:
         args.relationships = ['validates']
 

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -39,11 +39,19 @@ class TestCaseParser(NodeVisitor):
         tags = []
         for element in node.body:
             if element.type == Token.DOCUMENTATION:
+                in_docstring = False
+                previous_token = None
                 for token in element.tokens:
-                    if token.type == Token.ARGUMENT:
-                        doc += token.value + ' '
-                    elif token.type == Token.EOL:
-                        doc += r'\n'
+                    if in_docstring and token.type in (Token.ARGUMENT, Token.EOL, Token.SEPARATOR):
+                        if previous_token is None or previous_token.type != Token.CONTINUATION:
+                            doc += token.value
+                        elif len(token.value) > 2:
+                            doc += token.value[2:]  # remove two leading spaces, which are needed to separate the text
+                    elif token.type == Token.CONTINUATION:
+                        doc = doc.rstrip(' ')
+                    elif token.type == Token.DOCUMENTATION:
+                        in_docstring = True
+                    previous_token = token
             elif element.type == Token.TAGS:
                 tags = [el.value for el in element.tokens if el.type == Token.ARGUMENT]
 

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -1,6 +1,8 @@
 from ast import NodeVisitor
 from collections import namedtuple
 
+from robot.api import get_model, Token
+
 
 def extract_tests(robot_file):
     """ Extracts all useful information from the tests in the .robot file.
@@ -11,15 +13,10 @@ def extract_tests(robot_file):
     Returns:
         list: List of objects with attributes name (str), doc (str) and tags (list).
     """
-    try:
-        from robot.api import get_model  # pylint: disable=import-outside-toplevel
-        model = get_model(robot_file)
-        parser = TestCaseParser()
-        parser.visit(model)
-        return parser.tests
-    except ImportError:
-        from robot.parsing.model import TestData  # pylint: disable=import-outside-toplevel
-        return TestData(source=robot_file).testcase_table.tests
+    model = get_model(robot_file)
+    parser = TestCaseParser()
+    parser.visit(model)
+    return parser.tests
 
 
 class TestCaseParser(NodeVisitor):
@@ -34,7 +31,6 @@ class TestCaseParser(NodeVisitor):
         self.tests = []
 
     def visit_TestCase(self, node):
-        from robot.api import Token  # pylint: disable=import-outside-toplevel
         doc = ''
         tags = []
         for element in node.body:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/robot2rst'
 
-requires = ['robotframework', 'mlx.traceability', 'mako']
+requires = ['robotframework>=3.2', 'mlx.traceability', 'mako']
 
 setup(
     name='mlx.robot2rst',


### PR DESCRIPTION
This PR changes the way `[Documentation]` sections are processed. Robot Framework version 3.2 or later is now required. Line endings and indents are preserved, which means that you can use the power of reStructuredText.

Closes #18 

On top of #19 
