### PR TITLE
Explicitly specify default value for group option of item-matrix

### DIFF
--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -89,7 +89,7 @@ The below table traces the integration test cases to the ${relationship} require
     :targettitle: ${relationship} requirement
     :type: ${relationship}
     :stats:
-    :group:
+    :group: top
     :nocaptions:
 
 % endfor


### PR DESCRIPTION
Explicitly specify default value for group option of item-matrix for compatibility with [mlx.traceability==7.0.0](https://github.com/melexis/sphinx-traceability-extension/releases/tag/v7.0.0).