### PR TITLE
Drop mlx.traceability requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 project_url = 'https://github.com/melexis/robot2rst'
 
-requires = ['robotframework>=3.2', 'mlx.traceability', 'mako']
+requires = ['robotframework>=3.2', 'mako']
 
 setup(
     name='mlx.robot2rst',


### PR DESCRIPTION
It's better to drop the requirement for mlx.traceability as it isn't used by robot2rst.

Mlx.traceability also depends on non-pip libraries like libffi and libssl.
Sphinx (~15MB) and matplotlib (~25MB) are also quite large while both are unused in our integration setup.
