### PR TITLE
Replace travis-ci badge with github actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://github.com/melexis/robot2rst/actions/workflows/python-package.yml/badge.svg?branch=master
-    :target: https://github.com/melexis/sphinx-traceability-extension/actions/workflows/python-package.yml
+    :target: https://github.com/melexis/robot2rst/actions/workflows/python-package.yml
     :alt: Build status
 
 .. image:: https://img.shields.io/badge/Documentation-published-brightgreen.svg

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/melexis/sphinx-traceability-extension/actions/workflows/python-package.yml/badge.svg?branch=master
+.. image:: https://github.com/melexis/robot2rst/actions/workflows/python-package.yml/badge.svg?branch=master
     :target: https://github.com/melexis/sphinx-traceability-extension/actions/workflows/python-package.yml
     :alt: Build status
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://api.travis-ci.com/melexis/robot2rst.svg?branch=master
-    :target: https://travis-ci.com/melexis/robot2rst
+.. image:: https://github.com/melexis/sphinx-traceability-extension/actions/workflows/python-package.yml/badge.svg?branch=master
+    :target: https://github.com/melexis/sphinx-traceability-extension/actions/workflows/python-package.yml
     :alt: Build status
 
 .. image:: https://img.shields.io/badge/Documentation-published-brightgreen.svg


### PR DESCRIPTION
Forgot this while moving from Travis-CI to GitHub Actions