### PR TITLE
Use QTEST- and 'qualification' as the new defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Usage
                             matched by default.
       --type TYPE           Optional: give value that starts with 'i' or 'q' (case-insensitive) to
                             explicitly define the type of test: integration/qualification test. The
-                            default test type is 'integration'.
+                            default is 'integration'.
       --trim-suffix         If the suffix of any prefix or --tags argument ends with '_-' it gets
                             trimmed to '-'.
 

--- a/README.rst
+++ b/README.rst
@@ -51,16 +51,16 @@ Usage
       -o RST_FILE, --rst RST_FILE
                             Output RST file
       -p PREFIX, --prefix PREFIX
-                            Overrides the default 'ITEST-' prefix.
+                            Overrides the default 'QTEST-' prefix.
       -r [RELATIONSHIPS [RELATIONSHIPS ...]], --relationships [RELATIONSHIPS [RELATIONSHIPS ...]]
                             Name(s) of the relationship(s) used to link to items in Tags section.
                             The default value is 'validates'.
       -t [TAGS [TAGS ...]], --tags [TAGS [TAGS ...]]
                             Regex(es) for matching tags to add a relationship link for. All tags get
                             matched by default.
-      --type TYPE           Optional: give value that starts with 'i' or 'q' (case-insensitive) to
-                            explicitly define the type of test: integration/qualification test. The
-                            default is 'integration'.
+      --type TYPE           Give value that starts with 'q' or 'i' (case-insensitive) to
+                            explicitly define the type of test: qualification/integration test. The
+                            default is 'qualification'.
       --trim-suffix         If the suffix of any prefix or --tags argument ends with '_-' it gets
                             trimmed to '-'.
 

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Usage
     $ robot2rst --help
 
     usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [-p PREFIX]
-                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]]
-                     [-t [TAGS [TAGS ...]]] [--trim-suffix]
+                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]] [-t [TAGS [TAGS ...]]] [--type TYPE]
+                     [--trim-suffix]
 
     Convert robot test cases to reStructuredText with traceable items.
 
@@ -53,13 +53,16 @@ Usage
       -p PREFIX, --prefix PREFIX
                             Overrides the default 'ITEST-' prefix.
       -r [RELATIONSHIPS [RELATIONSHIPS ...]], --relationships [RELATIONSHIPS [RELATIONSHIPS ...]]
-                            Name(s) of the relationship(s) used to link to items
-                            in Tags section. The default value is 'validates'.
+                            Name(s) of the relationship(s) used to link to items in Tags section.
+                            The default value is 'validates'.
       -t [TAGS [TAGS ...]], --tags [TAGS [TAGS ...]]
-                            Regex(es) for matching tags to add a relationship link
-                            for. All tags get matched by default.
-      --trim-suffix         If the suffix of any prefix or --tags argument ends
-                            with '_-' it gets trimmed to '-'.
+                            Regex(es) for matching tags to add a relationship link for. All tags get
+                            matched by default.
+      --type TYPE           Optional: give value that starts with 'i' or 'q' (case-insensitive) to
+                            explicitly define the type of test: integration/qualification test. The
+                            default test type is 'integration'.
+      --trim-suffix         If the suffix of any prefix or --tags argument ends with '_-' it gets
+                            trimmed to '-'.
 
 -------------
 Configuration

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -80,12 +80,12 @@ Traceability Matrix
 ===================
 
 % for relationship, tag_regex in relationship_to_tag_mapping.items():
-The below table traces the integration test cases to the ${relationship} requirements.
+The below table traces the ${test_type} test cases to the ${relationship} requirements.
 
-.. item-matrix:: Linking these integration test cases to the ${relationship} requirements
+.. item-matrix:: Linking these ${test_type} test cases to the ${relationship} requirements
     :source: ${prefix}
     :target: ${tag_regex}
-    :sourcetitle: Integration test case
+    :sourcetitle: ${test_type.capitalize()} test case
     :targettitle: ${relationship} requirement
     :type: ${relationship}
     :stats:

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -76,7 +76,7 @@ ${generate_body(str(test.doc))}
 % endfor
 
 % if gen_matrix:
-Traceability matrix
+Traceability Matrix
 ===================
 
 % for relationship, tag_regex in relationship_to_tag_mapping.items():

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -83,17 +83,17 @@ def main():
                         action='store')
     parser.add_argument("-o", "--rst", dest='rst_file', help='Output RST file', required=True,
                         action='store')
-    parser.add_argument("-p", "--prefix", action='store', default='ITEST-',
-                        help="Overrides the default 'ITEST-' prefix.")
+    parser.add_argument("-p", "--prefix", action='store', default='QTEST-',
+                        help="Overrides the default 'QTEST-' prefix.")
     parser.add_argument("-r", "--relationships", nargs='*',
                         help="Name(s) of the relationship(s) used to link to items in Tags section. The default value "
                              "is 'validates'.")
     parser.add_argument("-t", "--tags", nargs='*',
                         help="Regex(es) for matching tags to add a relationship link for. All tags get matched by "
                              "default.")
-    parser.add_argument("--type", default='i',
-                        help="Optional: give value that starts with 'i' or 'q' (case-insensitive) to explicitly define "
-                             "the type of test: integration/qualification test. The default is 'integration'.")
+    parser.add_argument("--type", default='q',
+                        help="Give value that starts with 'q' or 'i' (case-insensitive) to explicitly define "
+                             "the type of test: qualification/integration test. The default is 'qualification'.")
     parser.add_argument("--trim-suffix", action='store_true',
                         help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'.")
 

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -93,8 +93,7 @@ def main():
                              "default.")
     parser.add_argument("--type", default='i',
                         help="Optional: give value that starts with 'i' or 'q' (case-insensitive) to explicitly define "
-                             "the type of test: integration/qualification test. The default test type is "
-                             "'integration'.")
+                             "the type of test: integration/qualification test. The default is 'integration'.")
     parser.add_argument("--trim-suffix", action='store_true',
                         help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'.")
 

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -93,7 +93,8 @@ def main():
                              "default.")
     parser.add_argument("--type", default='i',
                         help="Optional: give value that starts with 'i' or 'q' (case-insensitive) to explicitly define "
-                             "the type of test: integration/qualification test")
+                             "the type of test: integration/qualification test. The default test type is "
+                             "'integration'.")
     parser.add_argument("--trim-suffix", action='store_true',
                         help="If the suffix of any prefix or --tags argument ends with '_-' it gets trimmed to '-'.")
 


### PR DESCRIPTION
I added the `--type` option so that it is similar to the [`--type` option of mlx.xunit2rst](https://github.com/melexis/xunit2rst/blob/1.2.1/mlx/xunit2rst.py#L212). With this option, you can revert the behavior to the previous default 'integration'.