### PR TITLE
Support exclusion of the RST output based on tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,9 @@ Usage
 
     $ robot2rst --help
 
-    usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [-p PREFIX]
-                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]] [-t [TAGS [TAGS ...]]] [--type TYPE]
-                     [--trim-suffix]
+    usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [--only EXPRESSION] [-p PREFIX]
+                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]] [-t [TAGS [TAGS ...]]]
+                     [--type TYPE] [--trim-suffix]
 
     Convert robot test cases to reStructuredText with traceable items.
 
@@ -50,6 +50,8 @@ Usage
                             Input robot file
       -o RST_FILE, --rst RST_FILE
                             Output RST file
+      --only EXPRESSION     Expression of tags for Sphinx' `only` directive that surrounds all RST
+                            content. By default, no `only` directive is generated.
       -p PREFIX, --prefix PREFIX
                             Overrides the default 'QTEST-' prefix.
       -r [RELATIONSHIPS [RELATIONSHIPS ...]], --relationships [RELATIONSHIPS [RELATIONSHIPS ...]]
@@ -79,5 +81,11 @@ To include the script's output in your documentation you want to add the aforeme
 
 Please read the `documentation of mlx.traceability`_ for additional configuration steps.
 
+If you use the ``--only`` input argument, you should also add |sphinx_selective_exclude.eager_only|_ to the
+``extensions`` list to prevent mlx.traceability from parsing the content and ignoring the effect of the
+``only`` directive.
+
 .. _`mlx.traceability`: https://pypi.org/project/mlx.traceability/
 .. _`documentation of mlx.traceability`: https://melexis.github.io/sphinx-traceability-extension/readme.html
+.. |sphinx_selective_exclude.eager_only| replace:: ``'sphinx_selective_exclude.eager_only'``
+.. _sphinx_selective_exclude.eager_only: https://pypi.org/project/sphinx-selective-exclude/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,5 +18,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname
+	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname --only FLASH
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,4 +74,4 @@ html_static_path = [os.path.join(os.path.dirname(mlx.traceability.__file__), 'as
 
 
 def setup(app):
-    pass
+    tags.add('FLASH')

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -85,7 +85,7 @@ def main():
                         action='store')
     parser.add_argument("-o", "--rst", dest='rst_file', help='Output RST file', required=True,
                         action='store')
-    parser.add_argument("--only", default="",
+    parser.add_argument("--only", dest="expression", default="",
                         help="Expression of tags for Sphinx' `only` directive that surrounds all RST content. "
                         "By default, no `only` directive is generated.")
     parser.add_argument("-p", "--prefix", action='store', default='QTEST-',
@@ -133,7 +133,7 @@ def main():
     relationship_to_tag_mapping = dict(zip(relationships, tag_regexes))
 
     generate_robot_2_rst(Path(args.robot_file), Path(args.rst_file), prefix, relationship_to_tag_mapping, gen_matrix,
-                         test_type=test_type, only=args.only)
+                         test_type=test_type, only=args.expression)
 
 
 if __name__ == "__main__":

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -6,7 +6,6 @@ from textwrap import indent
 from pathlib import Path
 
 from mako.exceptions import RichTraceback
-from mako.runtime import Context
 from mako.template import Template
 
 from .robot_parser import extract_tests


### PR DESCRIPTION
Added a new optional input argument `--only EXPRESSION` to conditionally exclude the entire content of the RST file from the documentation, provided that the extension [sphinx-selective-exclude.eager_only](https://pypi.org/project/sphinx-selective-exclude/) is used.

The `EXPRESSION` exists of one or more tags and is explained in more detail in [Sphinx' documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#including-content-based-on-tags).