### PR TITLE
Include sphinx_selective_exclude in example documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,6 +36,7 @@ man_pages = [
 # ones.
 extensions = [
     'mlx.traceability',
+    'sphinx_selective_exclude.eager_only',
 ]
 
 traceability_relationships = {

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps=
     {[testenv]deps}
     sphinx <= 2.1.9999
     mlx.warnings >= 1.2.0
+    sphinx_selective_exclude >= 1.0.3
 whitelist_externals =
     bash
     make
@@ -62,6 +63,7 @@ deps=
     {[testenv]deps}
     sphinx
     mlx.warnings >= 1.2.0
+    sphinx_selective_exclude >= 1.0.3
 whitelist_externals =
     bash
     make


### PR DESCRIPTION
This addition was missing from PR #31 and may prevent confusion. It has no effect on the rendered example documentation, however.