### PR TITLE
Use output filename to generate a human readable title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ venv.bak/
 .mypy_cache/
 
 # generated files
-doc/source/example_usage.rst
+doc/source/*_qtp.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ recursive-include doc *.py
 recursive-include doc *.robot
 recursive-include doc *.rst
 recursive-include doc Makefile
-exclude doc/source/example_usage.rst
+exclude doc/source/*_qtp.rst
 exclude mlx/__robot2rst_version__.py
 
 # added by check_manifest.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,5 +18,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname --only FLASH
+	@$(ROBOT2RST) -i $(SOURCEDIR)/robot/example.robot -o $(SOURCEDIR)/example_usage_qtp.rst -t ^SWRQT- ^SYSRQT- -r validates ext_toolname --only FLASH
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/example.rst
+++ b/doc/source/example.rst
@@ -3,7 +3,8 @@ Example usage
 =============
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
+    :glob:
 
     requirements
-    example_usage
+    *_qtp

--- a/mlx/robot2rst.mako
+++ b/mlx/robot2rst.mako
@@ -1,6 +1,11 @@
 <%
 import re
 
+title = suite
+match = re.match(r"(.+)_[qi]tp", suite)
+if match:
+    title = f"{test_type.capitalize()} Test Plan for {match.group(1)}"
+
 def to_traceable_item(name, prefix=''):
     '''
     Converts a name, to the name of a traceabile item
@@ -49,9 +54,9 @@ def generate_body(input_string):
 %>\
 .. _${suite.replace(' ', '_')}:
 
-${'='*len(suite)}
-${suite}
-${'='*len(suite)}
+${'='*len(title)}
+${title}
+${'='*len(title)}
 
 .. contents:: `Contents`
     :depth: 2

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -81,8 +81,8 @@ def main():
     parser = argparse.ArgumentParser(description='Convert robot test cases to reStructuredText with traceable items.')
     parser.add_argument("-i", "--robot", dest='robot_file', help='Input robot file', required=True,
                         action='store')
-    parser.add_argument("-o", "--rst", dest='rst_file', help='Output RST file', required=True,
-                        action='store')
+    parser.add_argument("-o", "--rst", dest='rst_file', required=True,
+                        action='store', help='Output RST file, e.g. my_component_qtp.rst')
     parser.add_argument("--only", dest="expression", default="",
                         help="Expression of tags for Sphinx' `only` directive that surrounds all RST content. "
                         "By default, no `only` directive is generated.")

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -79,14 +79,14 @@ def _tweak_prefix(prefix):
 def main():
     '''Main entry point for script: parse arguments and execute'''
     parser = argparse.ArgumentParser(description='Convert robot test cases to reStructuredText with traceable items.')
-    parser.add_argument("-i", "--robot", dest='robot_file', help='Input robot file', required=True,
-                        action='store')
+    parser.add_argument("-i", "--robot", dest='robot_file', required=True,
+                        help='Input robot file')
     parser.add_argument("-o", "--rst", dest='rst_file', required=True,
-                        action='store', help='Output RST file, e.g. my_component_qtp.rst')
+                        help='Output RST file, e.g. my_component_qtp.rst')
     parser.add_argument("--only", dest="expression", default="",
                         help="Expression of tags for Sphinx' `only` directive that surrounds all RST content. "
                         "By default, no `only` directive is generated.")
-    parser.add_argument("-p", "--prefix", action='store', default='QTEST-',
+    parser.add_argument("-p", "--prefix", default='QTEST-',
                         help="Overrides the default 'QTEST-' prefix.")
     parser.add_argument("-r", "--relationships", nargs='*',
                         help="Name(s) of the relationship(s) used to link to items in Tags section. The default value "


### PR DESCRIPTION
`--output my_component_qtp.rst` results in the title `Qualification Test Plan for my_component` instead of `my_component_qtp`. 

This feature is automatically enabled when the filename ends with `_qtp` or `_itp`.