### PR TITLE
Fix AttributeError introduced in 3.2.0

### DIFF
--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -3,14 +3,15 @@ Documentation    Example using the space separated plain text format.
 Library          OperatingSystem
 
 *** Variables ***
+${NAMES}   Create List   First Name  Family Name  Email
 ${NAD}    ${0x63}
-${MESSAGE}       Hello,
+${MESSAGE}     Hello,
 ...    world!
 
 *** Test Cases ***
 First Test
     [Documentation]     Thorough and relatively lengthy documentation for the example test case that
-    ...  logs ${MESSAGE} and ${NAD}.
+    ...  logs ${MESSAGE} and ${NAD} and ${NAMES}.
     [Tags]              SWRQT-SOME_RQT  ANOTHER-TAG  SWRQT-OTHER_RQT  SYSRQT-SOME_SYSTEM_RQT
                         Log    ${MESSAGE}
                         Log    ${NAD}
@@ -31,10 +32,10 @@ Test with documentation in RST syntax
 
 Another Test
     [Documentation]
-    ...  Short documentation string.
+    ...  Test case with for-loop.
     [Tags]              RQT-SOME_RQT  SYSRQT-SOME_SYSTEM_RQT
-                        Log    ${MESSAGE}
-                        My Keyword    /tmp
+                        FOR     ${var}  IN  @{NAMES}
+                                Log     ${var}
 
 *** Keywords ***
 My Keyword

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -33,7 +33,8 @@ class ParserApplication(ModelVisitor):
 
     def visit_VariableSection(self, node):
         for element in node.body:
-            if getattr(element, 'type') == Token.VARIABLE:
+            element_type = getattr(element, 'type', None)
+            if element_type == Token.VARIABLE:
                 name = element.get_value(Token.VARIABLE)
                 value = ' '.join(element.get_values(Token.ARGUMENT))
                 match = re.fullmatch(r"\${(.+)}", value)
@@ -45,7 +46,8 @@ class ParserApplication(ModelVisitor):
         doc = ''
         tags = []
         for element in node.body:
-            if getattr(element, 'type') == Token.DOCUMENTATION:
+            element_type = getattr(element, 'type', None)
+            if element_type == Token.DOCUMENTATION:
                 in_docstring = False
                 previous_token = None
                 for token in element.tokens:
@@ -59,7 +61,7 @@ class ParserApplication(ModelVisitor):
                     elif token.type == Token.DOCUMENTATION:
                         in_docstring = True
                     previous_token = token
-            elif element.type == Token.TAGS:
+            elif element_type == Token.TAGS:
                 tags = [el.value for el in element.tokens if el.type == Token.ARGUMENT]
 
         self.tests.append(self.TestAttributes(node.name, doc, tags))


### PR DESCRIPTION
Example of error: `AttributeError: 'For' object has no attribute 'type'`