### PR TITLE
Filter test cases on tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,11 +59,13 @@ Usage
                             Name(s) of the relationship(s) used to link to items in Tags section.
                             The default value is 'validates'.
       -t [TAGS ...], --tags [TAGS ...]
-                            Regex(es) for matching tags to treat them as traceable targets via a
-                            relationship. All tags get matched by default.
+                            Zero or more Python regexes for matching tags to treat them as
+                            traceable targets via a relationship. All tags get matched by
+                            default.
       --include [INCLUDE ...]
-                            Regex(es) for matching tags to filter test cases. A test case is
-                            included if every regex matches at least one of its tags.
+                            Zero or more Python regexes for matching tags to filter test cases.
+                            If every regex matches at least one of a test case's tags, the test
+                            case is included.
       -c [COVERAGE ...], --coverage [COVERAGE ...]
                             Minimum coverage percentages for the item-matrix(es); 1 value per tag
                             in -t, --tags.

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Usage
                             Regex(es) for matching tags to filter test cases. A test case is
                             included if every regex matches at least one of its tags.
       -c [COVERAGE ...], --coverage [COVERAGE ...]
-                            Minumum coverage percentages for the item-matrix(es); 1 value per tag
+                            Minimum coverage percentages for the item-matrix(es); 1 value per tag
                             in -t, --tags.
       --type TYPE           Give value that starts with 'q' or 'i' (case-insensitive) to
                             explicitly define the type of test: qualification/integration test.

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ Usage
                             Regex(es) for matching tags to add a relationship link for. All tags
                             get matched by default.
       --tags-for-inclusion [TAGS_FOR_INCLUSION ...]
-                            Regex(es) for matching tags. Only test cases that have at least one
-                            matching tag are included. All are included by default.
+                            Regex(es) for matching tags. A test case is included if every regex
+                            matches at least one of its tags.
       -c [COVERAGE ...], --coverage [COVERAGE ...]
                             Minumum coverage percentages for the item-matrix(es); 1 value per tag
                             in -t, --tags.

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,8 @@ Usage
     $ robot2rst --help
 
     usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [--only EXPRESSION] [-p PREFIX]
-                     [-r [RELATIONSHIPS ...]] [-t [TAGS ...]]
-                     [--tags-for-inclusion [TAGS_FOR_INCLUSION ...]] [-c [COVERAGE ...]]
-                     [--type TYPE] [--trim-suffix]
+                     [-r [RELATIONSHIPS ...]] [-t [TAGS ...]] [--include [INCLUDE ...]]
+                     [-c [COVERAGE ...]] [--type TYPE] [--trim-suffix]
 
     Convert robot test cases to reStructuredText with traceable items.
 
@@ -52,8 +51,8 @@ Usage
                             Input robot file
       -o RST_FILE, --rst RST_FILE
                             Output RST file, e.g. my_component_qtp.rst
-      --only EXPRESSION     Expression of tags for Sphinx' `only` directive that surrounds all RST
-                            content. By default, no `only` directive is generated.
+      --only EXPRESSION     Expression of tags for Sphinx' `only` directive that surrounds all
+                            RST content. By default, no `only` directive is generated.
       -p PREFIX, --prefix PREFIX
                             Overrides the default 'QTEST-' prefix.
       -r [RELATIONSHIPS ...], --relationships [RELATIONSHIPS ...]
@@ -62,7 +61,7 @@ Usage
       -t [TAGS ...], --tags [TAGS ...]
                             Regex(es) for matching tags to treat them as traceable targets via a
                             relationship. All tags get matched by default.
-      --tags-for-inclusion [TAGS_FOR_INCLUSION ...]
+      --include [INCLUDE ...]
                             Regex(es) for matching tags to filter test cases. A test case is
                             included if every regex matches at least one of its tags.
       -c [COVERAGE ...], --coverage [COVERAGE ...]

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,8 @@ Usage
     $ robot2rst --help
 
     usage: robot2rst [-h] -i ROBOT_FILE -o RST_FILE [--only EXPRESSION] [-p PREFIX]
-                     [-r [RELATIONSHIPS [RELATIONSHIPS ...]]] [-t [TAGS [TAGS ...]]]
+                     [-r [RELATIONSHIPS ...]] [-t [TAGS ...]]
+                     [--tags-for-inclusion [TAGS_FOR_INCLUSION ...]] [-c [COVERAGE ...]]
                      [--type TYPE] [--trim-suffix]
 
     Convert robot test cases to reStructuredText with traceable items.
@@ -61,6 +62,9 @@ Usage
       -t [TAGS ...], --tags [TAGS ...]
                             Regex(es) for matching tags to add a relationship link for. All tags
                             get matched by default.
+      --tags-for-inclusion [TAGS_FOR_INCLUSION ...]
+                            Regex(es) for matching tags. Only test cases that have at least one
+                            matching tag are included. All are included by default.
       -c [COVERAGE ...], --coverage [COVERAGE ...]
                             Minumum coverage percentages for the item-matrix(es); 1 value per tag
                             in -t, --tags.

--- a/README.rst
+++ b/README.rst
@@ -60,11 +60,11 @@ Usage
                             Name(s) of the relationship(s) used to link to items in Tags section.
                             The default value is 'validates'.
       -t [TAGS ...], --tags [TAGS ...]
-                            Regex(es) for matching tags to add a relationship link for. All tags
-                            get matched by default.
+                            Regex(es) for matching tags to treat them as traceable targets via a
+                            relationship. All tags get matched by default.
       --tags-for-inclusion [TAGS_FOR_INCLUSION ...]
-                            Regex(es) for matching tags. A test case is included if every regex
-                            matches at least one of its tags.
+                            Regex(es) for matching tags to filter test cases. A test case is
+                            included if every regex matches at least one of its tags.
       -c [COVERAGE ...], --coverage [COVERAGE ...]
                             Minumum coverage percentages for the item-matrix(es); 1 value per tag
                             in -t, --tags.

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -97,7 +97,7 @@ def main():
     parser.add_argument("-t", "--tags", nargs='*',
                         help="Regex(es) for matching tags to treat them as traceable targets via a relationship. "
                              "All tags get matched by default.")
-    parser.add_argument("--tags-for-inclusion", nargs='*', default=[],
+    parser.add_argument("--include", nargs='*', default=[],
                         help="Regex(es) for matching tags to filter test cases. A test case is included if every "
                              "regex matches at least one of its tags.")
     parser.add_argument("-c", "--coverage", nargs='*',
@@ -140,7 +140,7 @@ def main():
                          f"percentages ({len(coverages)}).")
     relationship_config = [(relationships[i], tag_regexes[i], coverages[i]) for i in range(len(relationships))]
 
-    parser = ParserApplication(Path(args.robot_file), args.tags_for_inclusion)
+    parser = ParserApplication(Path(args.robot_file), args.include)
     parser.run()
     return generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
                                 gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -95,11 +95,11 @@ def main():
                         help="Name(s) of the relationship(s) used to link to items in Tags section. The default value "
                              "is 'validates'.")
     parser.add_argument("-t", "--tags", nargs='*',
-                        help="Regex(es) for matching tags to add a relationship link for. All tags get matched by "
-                             "default.")
+                        help="Regex(es) for matching tags to treat them as traceable targets via a relationship. "
+                             "All tags get matched by default.")
     parser.add_argument("--tags-for-inclusion", nargs='*', default=[],
-                        help="Regex(es) for matching tags. A test case is included if every regex matches at least "
-                             "one of its tags.")
+                        help="Regex(es) for matching tags to filter test cases. A test case is included if every "
+                             "regex matches at least one of its tags.")
     parser.add_argument("-c", "--coverage", nargs='*',
                         help="Minimum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -95,11 +95,11 @@ def main():
                         help="Name(s) of the relationship(s) used to link to items in Tags section. The default value "
                              "is 'validates'.")
     parser.add_argument("-t", "--tags", nargs='*',
-                        help="Regex(es) for matching tags to treat them as traceable targets via a relationship. "
-                             "All tags get matched by default.")
+                        help="Zero or more Python regexes for matching tags to treat them as traceable targets via a "
+                             "relationship. All tags get matched by default.")
     parser.add_argument("--include", nargs='*', default=[],
-                        help="Regex(es) for matching tags to filter test cases. A test case is included if every "
-                             "regex matches at least one of its tags.")
+                        help="Zero or more Python regexes for matching tags to filter test cases. A test case is "
+                             "included if every regex matches at least one of its tags.")
     parser.add_argument("-c", "--coverage", nargs='*',
                         help="Minimum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -98,8 +98,8 @@ def main():
                         help="Regex(es) for matching tags to add a relationship link for. All tags get matched by "
                              "default.")
     parser.add_argument("--tags-for-inclusion", nargs='*', default=[],
-                        help="Regex(es) for matching tags. Only test cases that have at least one matching tag are "
-                             "included. All are included by default.")
+                        help="Regex(es) for matching tags. A test case is included if every regex matches at least "
+                             "one of its tags.")
     parser.add_argument("-c", "--coverage", nargs='*',
                         help="Minumum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -142,8 +142,16 @@ def main():
 
     parser = ParserApplication(Path(args.robot_file), args.include)
     parser.run()
-    return generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
-                                gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)
+    if parser.tests:
+        exit_code = generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
+                                         gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)
+    else:
+        msg = f"robot2rst did not generate {args.rst_file} because {args.robot_file} does not contain any test cases"
+        if args.include:
+            msg += f" with tags matching all regexes {args.include}"
+        LOGGER.info(msg)
+        exit_code = 0
+    return exit_code
 
 
 def entrypoint():

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -101,7 +101,7 @@ def main():
                         help="Regex(es) for matching tags. A test case is included if every regex matches at least "
                              "one of its tags.")
     parser.add_argument("-c", "--coverage", nargs='*',
-                        help="Minumum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
+                        help="Minimum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',
                         help="Give value that starts with 'q' or 'i' (case-insensitive) to explicitly define "
                              "the type of test: qualification/integration test. The default is 'qualification'.")

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -98,8 +98,8 @@ def main():
                         help="Zero or more Python regexes for matching tags to treat them as traceable targets via a "
                              "relationship. All tags get matched by default.")
     parser.add_argument("--include", nargs='*', default=[],
-                        help="Zero or more Python regexes for matching tags to filter test cases. A test case is "
-                             "included if every regex matches at least one of its tags.")
+                        help="Zero or more Python regexes for matching tags to filter test cases. "
+                             "If every regex matches at least one of a test case's tags, the test case is included.")
     parser.add_argument("-c", "--coverage", nargs='*',
                         help="Minimum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',

--- a/mlx/robot2rst.py
+++ b/mlx/robot2rst.py
@@ -97,6 +97,9 @@ def main():
     parser.add_argument("-t", "--tags", nargs='*',
                         help="Regex(es) for matching tags to add a relationship link for. All tags get matched by "
                              "default.")
+    parser.add_argument("--tags-for-inclusion", nargs='*', default=[],
+                        help="Regex(es) for matching tags. Only test cases that have at least one matching tag are "
+                             "included. All are included by default.")
     parser.add_argument("-c", "--coverage", nargs='*',
                         help="Minumum coverage percentages for the item-matrix(es); 1 value per tag in -t, --tags.")
     parser.add_argument("--type", default='q',
@@ -137,7 +140,7 @@ def main():
                          f"percentages ({len(coverages)}).")
     relationship_config = [(relationships[i], tag_regexes[i], coverages[i]) for i in range(len(relationships))]
 
-    parser = ParserApplication(Path(args.robot_file))
+    parser = ParserApplication(Path(args.robot_file), args.tags_for_inclusion)
     parser.run()
     return generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
                                 gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -21,8 +21,8 @@ class ParserApplication(ModelVisitor):
 
         Args:
             robot_file (Path): Path to the .robot file.
-            include_tags (list): Regexes for matching tags to only include test cases that have at least one matching
-                tag.
+            include_tags (list): Regexes for matching tags. A test case is included if every regex matches at least
+                one of its tags.
         """
         super().__init__(*args, **kwargs)
         self.robot_file = str(robot_file.resolve(strict=True))
@@ -73,6 +73,8 @@ class ParserApplication(ModelVisitor):
         for pattern in self.tags_for_inclusion:
             regexp = re.compile(pattern)
             for tag in tags:
-                if regexp.search(tag):
-                    return True
-        return not bool(self.tags_for_inclusion)
+                if regexp.match(tag):
+                    break
+            else:
+                return False
+        return True

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -21,8 +21,8 @@ class ParserApplication(ModelVisitor):
 
         Args:
             robot_file (Path): Path to the .robot file.
-            include_tags (list): Regexes for matching tags. A test case is included if every regex matches at least
-                one of its tags.
+            tags_for_inclusion (list): Regexes for matching tags. A test case is included if every regex matches at
+                least one of its tags.
         """
         super().__init__(*args, **kwargs)
         self.robot_file = str(robot_file.resolve(strict=True))

--- a/mlx/robot_parser.py
+++ b/mlx/robot_parser.py
@@ -21,7 +21,8 @@ class ParserApplication(ModelVisitor):
 
         Args:
             robot_file (Path): Path to the .robot file.
-            include_tags (list): Regexes for matching tags to only include test cases that have at least one matching tag.
+            include_tags (list): Regexes for matching tags to only include test cases that have at least one matching
+                tag.
         """
         super().__init__(*args, **kwargs)
         self.robot_file = str(robot_file.resolve(strict=True))


### PR DESCRIPTION
Robot Framework allows you to only execute certain test cases based on the `Tags` section. This PR adds the option `--include` to filter test cases on tags. You can specify multiple regular expressions. Every regexp must match at least one tag of the test case for the test case to be included.