### PR TITLE
Fix the name used for logging

### DIFF
--- a/mlx/robot2rst/robot2rst.py
+++ b/mlx/robot2rst/robot2rst.py
@@ -12,7 +12,7 @@ from mako.template import Template
 from .robot_parser import ParserApplication
 
 TEMPLATE_FILE = Path(__file__).parent.joinpath('robot2rst.mako')
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger('robot2rst')
 
 
 def render_template(destination, only="", **kwargs):


### PR DESCRIPTION
Somehow `__main__` was used as the name.

`WARNING:__main__:No traceability matrix will be generated because of the use of default tag regex '.*'.`