### PR TITLE
Fix: include the Mako template in the wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
     packages=find_namespace_packages(where=".", exclude=("doc.*", "doc", "build*")),
     package_dir={"": "."},
     include_package_data=True,
+    package_data={
+        'mlx.robot2rst': ['*.mako'],
+    },
     install_requires=requires,
     python_requires='>=3.8',
     keywords=['robot', 'robotframework', 'sphinx', 'traceability'],


### PR DESCRIPTION
Since version 3.5.0, the tool was not usable due to `FileNotFoundError: [Errno 2] No such file or directory: '/home/gitlab-runner/hello/lib/python3.9/site-packages/mlx/robot2rst/robot2rst.mako'`