### PR TITLE
Support usage of environment variables inside robot documentation

### DIFF
--- a/doc/source/robot/example.robot
+++ b/doc/source/robot/example.robot
@@ -11,7 +11,7 @@ ${MESSAGE}     Hello,
 *** Test Cases ***
 First Test
     [Documentation]     Thorough and relatively lengthy documentation for the example test case that
-    ...  logs ${MESSAGE} and ${NAD} and ${NAMES}.
+    ...  logs ${MESSAGE} and ${NAD} and ${NAMES}. %{RUNTIME_VAR}
     [Tags]              SWRQT-SOME_RQT  ANOTHER-TAG  SWRQT-OTHER_RQT  SYSRQT-SOME_SYSTEM_RQT
                         Log    ${MESSAGE}
                         Log    ${NAD}

--- a/mlx/robot2rst/robot2rst.py
+++ b/mlx/robot2rst/robot2rst.py
@@ -2,7 +2,6 @@
 ''' Script to convert a robot test file to a reStructuredText file with traceable items '''
 import argparse
 import logging
-import os
 import sys
 from textwrap import indent
 from pathlib import Path

--- a/mlx/robot2rst/robot2rst.py
+++ b/mlx/robot2rst/robot2rst.py
@@ -55,7 +55,6 @@ def generate_robot_2_rst(parser, rst_file, prefix, relationship_config, gen_matr
         relationship_config (list): List of tuples that contain a relationship, tag_regex and coverage percentage
         gen_matrix (bool): True if traceability matrices are to be generated, False if not.
     """
-    env_vars = dict(os.environ)
     return render_template(
         rst_file,
         parser=parser,
@@ -63,7 +62,6 @@ def generate_robot_2_rst(parser, rst_file, prefix, relationship_config, gen_matr
         prefix=prefix,
         relationship_config=relationship_config,
         gen_matrix=gen_matrix,
-        **env_vars,
         **kwargs,
     )
 
@@ -145,6 +143,7 @@ def main():
 
     parser = ParserApplication(Path(args.robot_file), args.include)
     parser.run()
+
     if parser.tests:
         exit_code = generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
                                          gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)

--- a/mlx/robot2rst/robot2rst.py
+++ b/mlx/robot2rst/robot2rst.py
@@ -142,7 +142,6 @@ def main():
 
     parser = ParserApplication(Path(args.robot_file), args.include)
     parser.run()
-
     if parser.tests:
         exit_code = generate_robot_2_rst(parser, Path(args.rst_file), prefix, relationship_config,
                                          gen_matrix, test_type=test_type, only=args.expression, coverages=coverages)

--- a/mlx/robot2rst/robot2rst.py
+++ b/mlx/robot2rst/robot2rst.py
@@ -2,6 +2,7 @@
 ''' Script to convert a robot test file to a reStructuredText file with traceable items '''
 import argparse
 import logging
+import os
 import sys
 from textwrap import indent
 from pathlib import Path
@@ -54,6 +55,7 @@ def generate_robot_2_rst(parser, rst_file, prefix, relationship_config, gen_matr
         relationship_config (list): List of tuples that contain a relationship, tag_regex and coverage percentage
         gen_matrix (bool): True if traceability matrices are to be generated, False if not.
     """
+    env_vars = dict(os.environ)
     return render_template(
         rst_file,
         parser=parser,
@@ -61,6 +63,7 @@ def generate_robot_2_rst(parser, rst_file, prefix, relationship_config, gen_matr
         prefix=prefix,
         relationship_config=relationship_config,
         gen_matrix=gen_matrix,
+        **env_vars,
         **kwargs,
     )
 

--- a/mlx/robot2rst/robot_parser.py
+++ b/mlx/robot2rst/robot_parser.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import namedtuple
 
@@ -66,6 +67,11 @@ class ParserApplication(ModelVisitor):
                     previous_token = token
             elif element_type == Token.TAGS:
                 tags = [el.value for el in element.tokens if el.type == Token.ARGUMENT]
+
+        for var_name in re.findall(r'%\{(.+?)\}', doc):
+            if var_name in os.environ:
+                doc = doc.replace(f'%{{{var_name}}}', os.environ[var_name])
+
         if self.evaluate_inclusion(tags):
             self.tests.append(self.TestAttributes(node.name, doc, tags))
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ setenv =
     RUNTIME_VAR = Test env variable
 deps=
     {[testenv]deps}
+    setuptools<70
     jinja2 == 2.11.3
     markupsafe == 1.1.0
     docutils == 0.17

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ commands =
     flake8 mlx setup.py
 
 [testenv:sphinx2.4.5]
+setenv =
+    RUNTIME_VAR = Test env variable
 deps=
     {[testenv]deps}
     jinja2 == 2.11.3
@@ -67,6 +69,8 @@ commands=
     mlx-warnings --config warnings_config.yml --command make -C doc html
 
 [testenv:sphinx-latest]
+setenv =
+    RUNTIME_VAR = Test env variable
 deps=
     {[testenv]deps}
     sphinx


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for runtime environment variable substitution in test documentation. Documentation strings can now reference environment variables using the `%{VAR}` syntax pattern, which will be replaced with corresponding values at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->