### PR TITLE
Make sure stylechecker only checks documentation of the test cases 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ Style Checker & Fixer
 =====================
 
 You can also check and automatically fix the RST syntax and layout within the ``[Documentation]`` blocks of your Robot files.
+This functionality is provided for test case documentation only.
 
 .. code-block:: console
 
@@ -114,18 +115,34 @@ You can also check and automatically fix the RST syntax and layout within the ``
 
     $ robot2rst stylecheck --help
 
-    usage: robot2rst stylecheck [-h] [--fix] [--fail-on-layout] [--line-length LINE_LENGTH] [paths ...]
+    usage: robot2rst stylecheck [-h] [--fix] [--fail-on-layout] [--line-length LINE_LENGTH]
+                                [--enable-bold-headers] [--trailing-continuation]
+                                [paths ...]
 
     positional arguments:
-    paths                 One or more paths to files or folders to check. Default: current directory.
+      paths                 One or more paths to files or folders to check. Default: current
+                            directory.
 
     options:
-    -h, --help            show this help message and exit
-    --fix                 Automatically fix RST formatting inside Robot documentation blocks.
-    --fail-on-layout      Fail on RST layout issues as well as syntax issues.
-    --line-length LINE_LENGTH
-                            Max line length for RST blocks (note: the line length does not include the length
-                            of the [Documentation] tag for example). Default: 100.
+      -h, --help            show this help message and exit
+      --fix                 Automatically fix RST formatting inside Robot documentation
+                            blocks.
+      --fail-on-layout      Fail on RST layout issues as well as syntax issues.
+      --line-length LINE_LENGTH
+                            Max line length for RST blocks (note: the line length does not
+                            include the length of the [Documentation] tag for example).
+                            Default: 100.
+      --enable-bold-headers
+                            Make sure that bold lines are seen as header.
+      --trailing-continuation
+                            Add a trailing '...' continuation to preserve a blank line at the
+                            end of the docstring.
+
+
+
+.. note::
+    The style checker will only process documentation within ``[Test Case]`` sections. It ignores suite-level and
+    keyword documentation.
 
 
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ This functionality is provided for test case documentation only.
 
 
 .. note::
-    The style checker will only process documentation within ``[Test Case]`` sections. It ignores suite-level and
+    The style checker will only process documentation within the ``*** Test Cases ***`` section. It ignores suite-level and
     keyword documentation.
 
 

--- a/mlx/robot2rst/style_checker.py
+++ b/mlx/robot2rst/style_checker.py
@@ -146,9 +146,12 @@ class StyleChecker(ModelVisitor):
         Sets a flag to indicate that the visitor is inside a test case, so that the `visit_Documentation` method knows
         to process the documentation.
         """
+        previous = self._in_test_case
         self._in_test_case = True
-        self.generic_visit(node)
-        self._in_test_case = False
+        try:
+            self.generic_visit(node)
+        finally:
+            self._in_test_case = previous
 
     def visit_Documentation(self, node):
         """Visitor method for 'Documentation' nodes.

--- a/mlx/robot2rst/style_checker.py
+++ b/mlx/robot2rst/style_checker.py
@@ -220,7 +220,7 @@ class StyleChecker(ModelVisitor):
 
             doc_string, count = re.subn(r'([^\n])\n([ \t]*)([-*+]) ', fix_smushed_lists, doc_string)
             if count > 0:
-                LOGGER.warning("%s:%d: Fixed possible 'smushed' lists", self.robot_file, node.lineno)
+                LOGGER.info("%s:%d: Fixed possible 'smushed' lists", self.robot_file, node.lineno)
 
         manager = StyleManager(current_file=self.robot_file, line_map=current_map)
         try:

--- a/mlx/robot2rst/style_checker.py
+++ b/mlx/robot2rst/style_checker.py
@@ -131,6 +131,7 @@ class StyleChecker(ModelVisitor):
         self.enable_bold_headers = kwargs.get('enable_bold_headers', False)
         self.trailing_continuation = kwargs.get('trailing_continuation', False)
         self.model = get_model(robot_file)
+        self._in_test_case = False
 
         self.issues_found = False
         self.lint_issues_found = False
@@ -138,6 +139,16 @@ class StyleChecker(ModelVisitor):
     def run(self):
         """Runs the style checker on the parsed Robot Framework model."""
         self.visit(self.model)
+
+    def visit_TestCase(self, node):
+        """Visitor method for 'TestCase' nodes.
+
+        Sets a flag to indicate that the visitor is inside a test case, so that the `visit_Documentation` method knows
+        to process the documentation.
+        """
+        self._in_test_case = True
+        self.generic_visit(node)
+        self._in_test_case = False
 
     def visit_Documentation(self, node):
         """Visitor method for 'Documentation' nodes.
@@ -153,6 +164,9 @@ class StyleChecker(ModelVisitor):
            correctly.
         -  General RST formatting: Applies standard RST layout rules via the `docstrfmt` library.
         """
+        if not self._in_test_case:
+            return
+
         original_doc_string = node.value
         doc_string = original_doc_string
         if not doc_string.strip():

--- a/mlx/robot2rst/style_checker.py
+++ b/mlx/robot2rst/style_checker.py
@@ -242,7 +242,7 @@ class StyleChecker(ModelVisitor):
         lines = formatted_doc.splitlines()
         original_tokens = node.tokens
 
-        indentation = "    "
+        indentation = ""
         if original_tokens:
             # Get indentation from the first separator
             if original_tokens[0].type == Token.SEPARATOR:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -362,3 +362,293 @@ def test_line_numbers_in_warnings(caplog):
     assert f"{robot_file_to_fix}:3: Fixed possible 'smushed' lists" in log_text
     assert f"{robot_file_to_fix}:6: Bullet list ends without a blank line; unexpected unindent." in log_text
     assert f"{robot_file_to_fix}:16: Bullet list ends without a blank line; unexpected unindent." in log_text
+
+
+# Tests for PR changes: test-case-only scoping of visit_Documentation
+# and indentation fix in _rewrite_tokens
+
+def test_suite_documentation_is_ignored():
+    """Test that StyleChecker does not process suite-level documentation.
+
+    RST issues in the suite [Documentation] block must be silently ignored because
+    the style checker only targets test-case documentation.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        # Suite-level documentation has a bad bullet list (RST error), but no test cases
+        robot_file.write_text(
+            "*** Settings ***\n"
+            "Documentation    Here comes the bullet list:\n"
+            "...              - Bullet point\n"
+            "...              - without a newline\n"
+            "...              Some more text that should be on the next line.\n"
+            "\n"
+            "*** Test Cases ***\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+        checker.run()
+
+        assert not checker.issues_found
+        assert not checker.lint_issues_found
+
+
+def test_keyword_documentation_is_ignored():
+    """Test that StyleChecker skips documentation inside Keywords sections.
+
+    RST errors in keyword documentation must not be reported because the checker
+    only operates on test-case documentation.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        # Keyword documentation contains a bad bullet list (RST error)
+        robot_file.write_text(
+            "*** Keywords ***\n"
+            "My Keyword\n"
+            "    [Documentation]    Here comes a list:\n"
+            "    ...                - Bullet point\n"
+            "    ...                - without a newline\n"
+            "    ...                Some more text that should be on the next line.\n"
+            "    Log    something\n"
+            "\n"
+            "*** Test Cases ***\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+        checker.run()
+
+        assert not checker.issues_found
+        assert not checker.lint_issues_found
+
+
+def test_test_case_documentation_is_processed():
+    """Test that StyleChecker processes documentation inside test cases.
+
+    The same bad-bullet RST pattern that is ignored in keyword/suite documentation
+    must be detected when it appears inside a test case.  The bad-bullet pattern
+    is a layout issue (lint), so lint_issues_found is expected to be True.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text(
+            "*** Test Cases ***\n"
+            "Test With Bad Bullet\n"
+            "    [Documentation]    Here comes a list:\n"
+            "    ...                - Bullet point\n"
+            "    ...                - without a newline\n"
+            "    ...                Some more text that should be on the next line.\n"
+            "    Log    something\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+        checker.run()
+
+        # The bad-bullet RST pattern triggers a layout difference, so lint_issues_found must be True.
+        # This contrasts with keyword/suite docs where neither flag should be set.
+        assert checker.lint_issues_found
+
+
+def test_keyword_bad_rst_does_not_affect_clean_test_case():
+    """Test that RST errors in keyword docs don't pollute the checker result.
+
+    When a keyword has RST issues but the test case documentation is valid,
+    issues_found and lint_issues_found must both remain False.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text(
+            "*** Keywords ***\n"
+            "Bad Keyword\n"
+            "    [Documentation]    - Bullet point\n"
+            "    ...                - without a newline\n"
+            "    ...                Smushed text.\n"
+            "    Log    something\n"
+            "\n"
+            "*** Test Cases ***\n"
+            "Clean Test\n"
+            "    [Documentation]    Simple valid documentation.\n"
+            "    Log    Hello\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+        checker.run()
+
+        assert not checker.issues_found
+        assert not checker.lint_issues_found
+
+
+def test_in_test_case_flag_initial_state():
+    """Test that _in_test_case flag starts as False before visiting any node."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text("*** Test Cases ***\nTest\n    Log    Hello\n")
+        checker = StyleChecker(robot_file, fix=False)
+
+        assert checker._in_test_case is False
+
+
+def test_in_test_case_flag_restored_after_visit():
+    """Test that _in_test_case is False again after visit_TestCase returns.
+
+    The try/finally block must restore the previous value even if an exception
+    occurs during generic_visit.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text(
+            "*** Test Cases ***\n"
+            "Test One\n"
+            "    [Documentation]    First test.\n"
+            "    Log    Hello\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+
+        # Before run the flag should be False
+        assert checker._in_test_case is False
+        checker.run()
+        # After run the flag must be restored to False
+        assert checker._in_test_case is False
+
+
+def test_in_test_case_flag_is_true_during_generic_visit():
+    """Test that _in_test_case is True while generic_visit processes a TestCase node.
+
+    We verify this by subclassing StyleChecker and recording the flag value
+    inside an overridden generic_visit call.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text(
+            "*** Test Cases ***\n"
+            "Test One\n"
+            "    [Documentation]    Some docs.\n"
+            "    Log    Hello\n"
+        )
+
+        flag_values_during_visit = []
+
+        class CapturingChecker(StyleChecker):
+            def generic_visit(self, node):
+                flag_values_during_visit.append(self._in_test_case)
+                super().generic_visit(node)
+
+        checker = CapturingChecker(robot_file, fix=False)
+        checker.run()
+
+        # At least one generic_visit call should have seen _in_test_case as True
+        assert any(flag_values_during_visit), (
+            "Expected _in_test_case to be True during at least one generic_visit call, "
+            f"but recorded values were: {flag_values_during_visit}"
+        )
+
+
+def test_in_test_case_flag_restored_to_previous_not_just_false():
+    """Test that visit_TestCase restores the *previous* value, not just False.
+
+    This is a regression guard for the try/finally pattern: if _in_test_case
+    is True before entering visit_TestCase, it must still be True afterwards.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        robot_file.write_text(
+            "*** Test Cases ***\n"
+            "Test One\n"
+            "    [Documentation]    Some docs.\n"
+            "    Log    Hello\n"
+        )
+        checker = StyleChecker(robot_file, fix=False)
+
+        # Artificially pre-set the flag to True, simulating a nested call
+        checker._in_test_case = True
+
+        # Manually call visit_TestCase on the first test-case node
+        from robot.api import get_model
+        model = checker.model
+        test_case_node = next(
+            tc for section in model.sections
+            for tc in getattr(section, 'body', [])
+            if hasattr(tc, 'name')
+        )
+        checker.visit_TestCase(test_case_node)
+
+        # The flag must be restored to what it was before: True
+        assert checker._in_test_case is True
+
+
+def test_suite_doc_with_bad_rst_does_not_trigger_fix(caplog):
+    """Test that --fix does not modify suite-level documentation.
+
+    Because suite-level docs are skipped, the file must remain unchanged even
+    when --fix is requested.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        bad_suite_doc_content = (
+            "*** Settings ***\n"
+            "Documentation    Here comes a list:\n"
+            "...              - Bullet point\n"
+            "...              - without a newline\n"
+            "...              Some more text.\n"
+            "\n"
+            "*** Test Cases ***\n"
+        )
+        robot_file.write_text(bad_suite_doc_content)
+
+        checker = StyleChecker(robot_file, fix=True)
+        checker.run()
+
+        assert not checker.issues_found
+        assert not checker.lint_issues_found
+        # File content must be unchanged because the suite doc was not processed
+        assert robot_file.read_text() == bad_suite_doc_content
+
+
+def test_rewrite_tokens_indentation_from_separator():
+    """Test that _rewrite_tokens derives indentation from the token separator, not a hardcoded value.
+
+    Before this PR, indentation was hardcoded to '    ' (4 spaces). After the PR,
+    it defaults to '' and then reads the actual separator from original_tokens.
+    This test verifies that the reformatted file preserves the indentation from the
+    robot file's separator token (typically 4 spaces for standard robot files).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        robot_file = tmppath / "test.robot"
+        # Write a robot file where the [Documentation] block uses standard 4-space indentation
+        # and has a long line that the formatter will need to wrap (triggering _rewrite_tokens)
+        long_line = "word " * 25  # ~125 chars, will be wrapped at default 100
+        robot_file.write_text(
+            "*** Test Cases ***\n"
+            "Test Case\n"
+            f"    [Documentation]    {long_line.strip()}\n"
+            "    Log    Hello\n"
+        )
+
+        checker = StyleChecker(robot_file, fix=True)
+        checker.run()
+
+        # Formatting should have found layout issues (line too long) and fixed them
+        assert checker.lint_issues_found
+
+        # Persist the in-memory token changes to disk (normally done by robot2rst.py)
+        checker.model.save(robot_file)
+
+        # After fix, read the reformatted file and check that continuation lines
+        # start with the separator from the original token (4 spaces), not a hardcoded value
+        fixed_content = robot_file.read_text()
+        lines = fixed_content.splitlines()
+
+        # Find continuation lines (lines with '...')
+        continuation_lines = [line for line in lines if line.lstrip().startswith("...")]
+        assert continuation_lines, "Expected at least one continuation line after fix"
+
+        for line in continuation_lines:
+            # The continuation line prefix comes from the separator token (4 spaces)
+            assert line.startswith("    "), (
+                f"Expected continuation line to start with 4-space separator indent, got: {line!r}"
+            )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -617,6 +617,7 @@ def test_suite_doc_with_bad_rst_does_not_trigger_fix(caplog):
 
         checker = StyleChecker(robot_file, fix=True)
         checker.run()
+        checker.model.save(robot_file)
 
         assert not checker.issues_found
         assert not checker.lint_issues_found

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -507,8 +507,24 @@ def test_in_test_case_flag_restored_after_visit():
 
         # Before run the flag should be False
         assert checker._in_test_case is False
-        checker.run()
-        # After run the flag must be restored to False
+
+        # Monkeypatch generic_visit to raise an exception
+        original_generic_visit = checker.generic_visit
+
+        def failing_generic_visit(node):
+            original_generic_visit(node)
+            raise RuntimeError("Deliberate exception for testing")
+
+        checker.generic_visit = failing_generic_visit
+
+        # Run should raise the exception, but the flag must still be restored
+        try:
+            checker.run()
+        except RuntimeError as e:
+            if "Deliberate exception for testing" not in str(e):
+                raise
+
+        # After run (even with exception), the flag must be restored to False
         assert checker._in_test_case is False
 
 
@@ -614,19 +630,20 @@ def test_rewrite_tokens_indentation_from_separator():
     Before this PR, indentation was hardcoded to '    ' (4 spaces). After the PR,
     it defaults to '' and then reads the actual separator from original_tokens.
     This test verifies that the reformatted file preserves the indentation from the
-    robot file's separator token (typically 4 spaces for standard robot files).
+    robot file's separator token. We use a non-default 2-space separator to ensure
+    the test can catch regression to a hardcoded 4-space indent.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
         robot_file = tmppath / "test.robot"
-        # Write a robot file where the [Documentation] block uses standard 4-space indentation
+        # Write a robot file where the [Documentation] block uses 2-space indentation
         # and has a long line that the formatter will need to wrap (triggering _rewrite_tokens)
         long_line = "word " * 25  # ~125 chars, will be wrapped at default 100
         robot_file.write_text(
             "*** Test Cases ***\n"
             "Test Case\n"
-            f"    [Documentation]    {long_line.strip()}\n"
-            "    Log    Hello\n"
+            f"  [Documentation]  {long_line.strip()}\n"
+            "  Log  Hello\n"
         )
 
         checker = StyleChecker(robot_file, fix=True)
@@ -639,7 +656,7 @@ def test_rewrite_tokens_indentation_from_separator():
         checker.model.save(robot_file)
 
         # After fix, read the reformatted file and check that continuation lines
-        # start with the separator from the original token (4 spaces), not a hardcoded value
+        # use the separator from the original token (2 spaces), not a hardcoded value
         fixed_content = robot_file.read_text()
         lines = fixed_content.splitlines()
 
@@ -648,7 +665,9 @@ def test_rewrite_tokens_indentation_from_separator():
         assert continuation_lines, "Expected at least one continuation line after fix"
 
         for line in continuation_lines:
-            # The continuation line prefix comes from the separator token (4 spaces)
-            assert line.startswith("    "), (
-                f"Expected continuation line to start with 4-space separator indent, got: {line!r}"
+            # Extract the prefix before the continuation marker
+            prefix_before_dots = line[:line.index("...")]
+            # The prefix must exactly match the 2-space separator from the original file
+            assert prefix_before_dots == "  ", (
+                f"Expected continuation line prefix to be '  ' (2 spaces), got: {prefix_before_dots!r}"
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated stylecheck docs and CLI usage text—added options for bold headers and trailing-continuation; clarified checks apply only to documentation inside [Test Case] sections.

* **Bug Fixes**
  * Fixed continuation-line indentation behavior during auto-fix so rewritten lines follow original separator-derived indentation.

* **Tests**
  * Added tests covering test-case-only checks, fix behavior, and indentation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->